### PR TITLE
StrEnum was not a member of enum before python3.11. Updated pyproject…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/kubiyak/remote_log_analysis"
 packages = [{include = "remote_log_analysis"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 pytest = "^7.4.0"
 fabric = "^3.1.0"
 pytest-cov = "^4.1.0"


### PR DESCRIPTION
….toml to reflect that.

Will tag a new release.